### PR TITLE
fix: code improvements and modernization

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
-# Set C++ standard
-set(CMAKE_CXX_STANDARD 17)
+# Set C++ standard using modern CMake approach
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # ImGui math operators for ImGuizmo
 add_compile_definitions(IMGUI_DEFINE_MATH_OPERATORS)

--- a/src/Mochii/CMakeLists.txt
+++ b/src/Mochii/CMakeLists.txt
@@ -32,6 +32,9 @@ target_include_directories(mochii PRIVATE
     ${fmt_SOURCE_DIR}/include
 )
 
+# Set C++ standard using modern CMake
+target_compile_features(mochii PUBLIC cxx_std_17)
+
 # Link libraries
 target_link_libraries(mochii PUBLIC
     glad

--- a/src/Mochii/src/Mochii/Core/Application.cpp
+++ b/src/Mochii/src/Mochii/Core/Application.cpp
@@ -68,7 +68,7 @@ void Application::Run() {
     MI_PROFILE_SCOPE("RunLoop");
 
     float time = (float)glfwGetTime();
-    Timestep timestep = time - _LastFrameTime;
+    Timestep timestep = _LastFrameTime == 0.0f ? 0.016f : time - _LastFrameTime;
     _LastFrameTime = time;
 
     if (!_Minimized) {

--- a/src/Mochii/src/Mochii/Core/Application.h
+++ b/src/Mochii/src/Mochii/Core/Application.h
@@ -43,7 +43,7 @@ class Application {
   bool OnWindowResize(WindowResizeEvent& e);
 
   std::unique_ptr<Window> _Window;
-  ImGuiLayer* _ImGuiLayer;
+  ImGuiLayer* _ImGuiLayer = nullptr;
   bool _Running = true;
   bool _Minimized = false;
   LayerStack _LayerStack;

--- a/src/Mochii/src/Mochii/Events/ApplicationEvent.h
+++ b/src/Mochii/src/Mochii/Events/ApplicationEvent.h
@@ -18,7 +18,7 @@ class WindowResizeEvent : public Event {
   }
 
   EVENT_CLASS_TYPE(WindowResize)
-  EVENT_CLASS_CATEGORY(EventCategoryApplication)
+  EVENT_CLASS_CATEGORY(EventCategory::Application)
  private:
   unsigned int m_Width, m_Height;
 };
@@ -28,7 +28,7 @@ class WindowCloseEvent : public Event {
   WindowCloseEvent() = default;
 
   EVENT_CLASS_TYPE(WindowClose)
-  EVENT_CLASS_CATEGORY(EventCategoryApplication)
+  EVENT_CLASS_CATEGORY(EventCategory::Application)
 };
 
 class AppTickEvent : public Event {
@@ -36,7 +36,7 @@ class AppTickEvent : public Event {
   AppTickEvent() = default;
 
   EVENT_CLASS_TYPE(AppTick)
-  EVENT_CLASS_CATEGORY(EventCategoryApplication)
+  EVENT_CLASS_CATEGORY(EventCategory::Application)
 };
 
 class AppUpdateEvent : public Event {
@@ -44,7 +44,7 @@ class AppUpdateEvent : public Event {
   AppUpdateEvent() = default;
 
   EVENT_CLASS_TYPE(AppUpdate)
-  EVENT_CLASS_CATEGORY(EventCategoryApplication)
+  EVENT_CLASS_CATEGORY(EventCategory::Application)
 };
 
 class AppRenderEvent : public Event {
@@ -52,6 +52,6 @@ class AppRenderEvent : public Event {
   AppRenderEvent() = default;
 
   EVENT_CLASS_TYPE(AppRender)
-  EVENT_CLASS_CATEGORY(EventCategoryApplication)
+  EVENT_CLASS_CATEGORY(EventCategory::Application)
 };
 }  // namespace Mochii

--- a/src/Mochii/src/Mochii/Events/Event.h
+++ b/src/Mochii/src/Mochii/Events/Event.h
@@ -23,13 +23,13 @@ enum class EventType {
   MouseScrolled
 };
 
-enum EventCategory {
+enum class EventCategory : uint32_t {
   None = 0,
-  EventCategoryApplication = BIT(0),
-  EventCategoryInput = BIT(1),
-  EventCategoryKeyboard = BIT(2),
-  EventCategoryMouse = BIT(3),
-  EventCategoryMouseButton = BIT(4)
+  Application = BIT(0),
+  Input = BIT(1),
+  Keyboard = BIT(2),
+  Mouse = BIT(3),
+  MouseButton = BIT(4)
 };
 
 #define EVENT_CLASS_TYPE(type)                                                \
@@ -38,7 +38,7 @@ enum EventCategory {
   virtual const char* GetName() const override { return #type; }
 
 #define EVENT_CLASS_CATEGORY(category) \
-  virtual int GetCategoryFlags() const override { return category; }
+  virtual uint32_t GetCategoryFlags() const override { return static_cast<uint32_t>(category); }
 
 class Event {
  public:
@@ -48,11 +48,11 @@ class Event {
 
   virtual EventType GetEventType() const = 0;
   virtual const char* GetName() const = 0;
-  virtual int GetCategoryFlags() const = 0;
+  virtual uint32_t GetCategoryFlags() const = 0;
   virtual std::string ToString() const { return GetName(); }
 
   bool IsInCategory(EventCategory category) {
-    return GetCategoryFlags() & category;
+    return GetCategoryFlags() & static_cast<uint32_t>(category);
   }
 };
 

--- a/src/Mochii/src/Mochii/Events/Event.h
+++ b/src/Mochii/src/Mochii/Events/Event.h
@@ -32,6 +32,14 @@ enum class EventCategory : uint32_t {
   MouseButton = BIT(4)
 };
 
+inline uint32_t operator|(EventCategory a, EventCategory b) {
+  return static_cast<uint32_t>(a) | static_cast<uint32_t>(b);
+}
+
+inline uint32_t operator|(uint32_t a, EventCategory b) {
+  return a | static_cast<uint32_t>(b);
+}
+
 #define EVENT_CLASS_TYPE(type)                                                \
   static EventType GetStaticType() { return EventType::type; }                \
   virtual EventType GetEventType() const override { return GetStaticType(); } \

--- a/src/Mochii/src/Mochii/Events/KeyEvent.h
+++ b/src/Mochii/src/Mochii/Events/KeyEvent.h
@@ -7,7 +7,7 @@ class KeyEvent : public Event {
  public:
   KeyCode GetKeyCode() const { return m_KeyCode; }
 
-  EVENT_CLASS_CATEGORY(EventCategoryKeyboard | EventCategoryInput)
+  EVENT_CLASS_CATEGORY(EventCategory::Keyboard | EventCategory::Input)
  protected:
   KeyEvent(const KeyCode keycode) : m_KeyCode(keycode) {}
 

--- a/src/Mochii/src/Mochii/Events/MouseEvent.h
+++ b/src/Mochii/src/Mochii/Events/MouseEvent.h
@@ -17,8 +17,8 @@ class MouseMovedEvent : public Event {
   }
 
   EVENT_CLASS_TYPE(MouseMoved)
-  EVENT_CLASS_CATEGORY(EventCategoryMouse | EventCategoryInput |
-                       EventCategoryMouseButton)
+  EVENT_CLASS_CATEGORY(EventCategory::Mouse | EventCategory::Input |
+                       EventCategory::MouseButton)
  private:
   float m_MouseX, m_MouseY;
 };
@@ -38,7 +38,7 @@ class MouseScrolledEvent : public Event {
   }
 
   EVENT_CLASS_TYPE(MouseScrolled)
-  EVENT_CLASS_CATEGORY(EventCategoryMouse | EventCategoryInput)
+  EVENT_CLASS_CATEGORY(EventCategory::Mouse | EventCategory::Input)
  private:
   float m_XOffset, m_YOffset;
 };
@@ -47,7 +47,7 @@ class MouseButtonEvent : public Event {
  public:
   MouseCode GetMouseButton() const { return m_Button; }
 
-  EVENT_CLASS_CATEGORY(EventCategoryMouse | EventCategoryInput)
+  EVENT_CLASS_CATEGORY(EventCategory::Mouse | EventCategory::Input)
  protected:
   MouseButtonEvent(const MouseCode button) : m_Button(button) {}
 

--- a/src/Mochii/src/Mochii/ImGui/ImGuiLayer.cpp
+++ b/src/Mochii/src/Mochii/ImGui/ImGuiLayer.cpp
@@ -62,8 +62,8 @@ void ImGuiLayer::OnDetach() {
 
 void ImGuiLayer::OnEvent(Event& e) {
   ImGuiIO& io = ImGui::GetIO();
-  e.Handled |= e.IsInCategory(EventCategoryMouse) && io.WantCaptureMouse;
-  e.Handled |= e.IsInCategory(EventCategoryKeyboard) && io.WantCaptureKeyboard;
+  e.Handled |= e.IsInCategory(EventCategory::Mouse) && io.WantCaptureMouse;
+  e.Handled |= e.IsInCategory(EventCategory::Keyboard) && io.WantCaptureKeyboard;
 }
 
 void ImGuiLayer::Begin() {

--- a/src/Mochii/src/Mochii/Platform/OpenGL/OpenGLContext.cpp
+++ b/src/Mochii/src/Mochii/Platform/OpenGL/OpenGLContext.cpp
@@ -25,7 +25,7 @@ void OpenGLContext::Init() {
 
   MI_CORE_ASSERT(
       GLVersion.major > 4 || (GLVersion.major == 4 && GLVersion.minor >= 5),
-      "Hazel requires at least OpenGL version 4.5!");
+      "Mochii requires at least OpenGL version 4.5!");
 }
 
 void OpenGLContext::SwapBuffers() {

--- a/src/Mochii/src/Mochii/Platform/OpenGL/OpenGLFramebuffer.cpp
+++ b/src/Mochii/src/Mochii/Platform/OpenGL/OpenGLFramebuffer.cpp
@@ -184,7 +184,7 @@ void OpenGLFramebuffer::Unbind() { glBindFramebuffer(GL_FRAMEBUFFER, 0); }
 void OpenGLFramebuffer::Resize(uint32_t width, uint32_t height) {
   if (width == 0 || height == 0 || width > s_MaxFramebufferSize ||
       height > s_MaxFramebufferSize) {
-    MI_CORE_WARN("Attempted to rezize framebuffer to {0}, {1}", width, height);
+    MI_CORE_WARN("Attempted to resize framebuffer to {0}, {1}", width, height);
     return;
   }
   m_Specification.Width = width;

--- a/src/Mochii/src/Mochii/Platform/OpenGL/OpenGLRendererAPI.cpp
+++ b/src/Mochii/src/Mochii/Platform/OpenGL/OpenGLRendererAPI.cpp
@@ -33,7 +33,7 @@ void OpenGLRendererAPI::Init() {
   glDebugMessageCallback(OpenGLMessageCallback, nullptr);
 
   glDebugMessageControl(GL_DONT_CARE, GL_DONT_CARE,
-                        GL_DEBUG_SEVERITY_NOTIFICATION, 0, NULL, GL_FALSE);
+                         GL_DEBUG_SEVERITY_NOTIFICATION, 0, nullptr, GL_FALSE);
 #endif
 
   glEnable(GL_BLEND);

--- a/src/Mochii/src/Mochii/Platform/OpenGL/OpenGLTexture.h
+++ b/src/Mochii/src/Mochii/Platform/OpenGL/OpenGLTexture.h
@@ -17,7 +17,9 @@ class OpenGLTexture2D : public Texture2D {
   virtual void Bind(uint32_t slot = 0) const override;
 
   virtual bool operator==(const Texture& other) const override {
-    return _RendererID == ((OpenGLTexture2D&)other)._RendererID;
+    const auto* otherTexture = dynamic_cast<const OpenGLTexture2D*>(&other);
+    if (!otherTexture) return false;
+    return _RendererID == otherTexture->_RendererID;
   }
 
  private:

--- a/src/Mochii/src/Mochii/Renderer/EditorCamera.cpp
+++ b/src/Mochii/src/Mochii/Renderer/EditorCamera.cpp
@@ -9,12 +9,12 @@
 namespace Mochii {
 EditorCamera::EditorCamera(float fov, float aspectRatio, float nearClip,
                            float farClip)
-    : m_FOV(fov),
+    : Camera(
+          glm::perspective(glm::radians(fov), aspectRatio, nearClip, farClip)),
+      m_FOV(fov),
       m_AspectRatio(aspectRatio),
       m_NearClip(nearClip),
-      m_FarClip(farClip),
-      Camera(
-          glm::perspective(glm::radians(fov), aspectRatio, nearClip, farClip)) {
+      m_FarClip(farClip) {
   UpdateView();
 }
 

--- a/src/Mochii/src/Mochii/Renderer/Renderer2D.cpp
+++ b/src/Mochii/src/Mochii/Renderer/Renderer2D.cpp
@@ -115,6 +115,16 @@ void Renderer2D::BeginScene(const Camera& camera, const glm::mat4& transform) {
   StartBatch();
 }
 
+void Renderer2D::BeginScene(const OrthographicCamera& camera) {
+  MI_PROFILE_FUNCTION();
+
+  s_Data.TextureShader->Bind();
+  s_Data.TextureShader->SetMat4("u_ViewProjection",
+                                camera.GetViewProjectionMatrix());
+
+  StartBatch();
+}
+
 void Renderer2D::BeginScene(const EditorCamera& camera) {
   MI_PROFILE_FUNCTION();
 

--- a/src/Mochii/src/Mochii/Renderer/Renderer2D.cpp
+++ b/src/Mochii/src/Mochii/Renderer/Renderer2D.cpp
@@ -19,10 +19,10 @@ struct QuadVertex {
 };
 
 struct Renderer2DData {
-  static const uint32_t MaxQuads = 20000;
-  static const uint32_t MaxVertices = MaxQuads * 4;
-  static const uint32_t MaxIndices = MaxQuads * 6;
-  static const uint32_t MaxTextureSlots = 32;
+  static constexpr uint32_t MaxQuads = 20000;
+  static constexpr uint32_t MaxVertices = MaxQuads * 4;
+  static constexpr uint32_t MaxIndices = MaxQuads * 6;
+  static constexpr uint32_t MaxTextureSlots = 32;
 
   Ref<VertexArray> QuadVertexArray;
   Ref<VertexBuffer> QuadVertexBuffer;

--- a/src/Mochii/src/Mochii/Renderer/Renderer2D.cpp
+++ b/src/Mochii/src/Mochii/Renderer/Renderer2D.cpp
@@ -104,16 +104,6 @@ void Renderer2D::Init() {
 
 void Renderer2D::Shutdown() { MI_PROFILE_FUNCTION(); }
 
-void Renderer2D::BeginScene(const OrthographicCamera& camera) {
-  MI_PROFILE_FUNCTION();
-
-  s_Data.TextureShader->Bind();
-  s_Data.TextureShader->SetMat4("u_ViewProjection",
-                                camera.GetViewProjectionMatrix());
-
-  StartBatch();
-}
-
 void Renderer2D::BeginScene(const Camera& camera, const glm::mat4& transform) {
   MI_PROFILE_FUNCTION();
 

--- a/src/Mochii/src/Mochii/Renderer/Renderer2D.cpp
+++ b/src/Mochii/src/Mochii/Renderer/Renderer2D.cpp
@@ -320,7 +320,7 @@ void Renderer2D::DrawSprite(const glm::mat4& transform,
   DrawQuad(transform, src.Color, entityID);
 }
 
-void Renderer2D::ResetStats() { memset(&s_Data.Stats, 0, sizeof(Statistics)); }
+void Renderer2D::ResetStats() { s_Data.Stats = {}; }
 
 Renderer2D::Statistics Renderer2D::GetStats() { return s_Data.Stats; }
 }  // namespace Mochii

--- a/src/Mochii/src/Mochii/Renderer/Renderer2D.h
+++ b/src/Mochii/src/Mochii/Renderer/Renderer2D.h
@@ -13,7 +13,6 @@ class Renderer2D {
 
   static void BeginScene(const Camera& camera, const glm::mat4& transform);
   static void BeginScene(const EditorCamera& camera);
-  static void BeginScene(const OrthographicCamera& camera);  // TODO: Remove
   static void EndScene();
   static void Flush();
 

--- a/src/Mochii/src/Mochii/Renderer/Renderer2D.h
+++ b/src/Mochii/src/Mochii/Renderer/Renderer2D.h
@@ -13,6 +13,7 @@ class Renderer2D {
 
   static void BeginScene(const Camera& camera, const glm::mat4& transform);
   static void BeginScene(const EditorCamera& camera);
+  static void BeginScene(const OrthographicCamera& camera);
   static void EndScene();
   static void Flush();
 

--- a/src/Mochii/src/Mochii/Scene/SceneSerializer.cpp
+++ b/src/Mochii/src/Mochii/Scene/SceneSerializer.cpp
@@ -189,11 +189,11 @@ bool SceneSerializer::Deserialize(const std::string& filepath) {
       auto tagComponent = entity["TagComponent"];
       if (tagComponent) name = tagComponent["Tag"].as<std::string>();
 
-      MI_CORE_TRACE("Deserialized entity with ID = {0}, name = {1}", uuid,
-                    name);
+       MI_CORE_TRACE("Deserialized entity with ID = {0}, name = {1}", uuid,
+                     name);
 
-      Entity deserializedEntity = m_Scene->CreateEntity(name);
-      deserializedEntity.GetComponent<UUIDComponent>().UUID = uuid;
+       Entity deserializedEntity = m_Scene->CreateEntity(name);
+       deserializedEntity.AddComponent<UUIDComponent>().UUID = uuid;
 
       auto transformComponent = entity["TransformComponent"];
       if (transformComponent) {

--- a/src/MochiiEditor/src/EditorLayer.cpp
+++ b/src/MochiiEditor/src/EditorLayer.cpp
@@ -151,7 +151,6 @@ void EditorLayer::OnImGuiRender() {
       // Disabling fullscreen would allow the window to be moved to the front of
       // other windows, which we can't undo at the moment without finer window
       // depth/z control.
-      // ImGui::MenuItem("Fullscreen", NULL, &opt_fullscreen_persistant);1
       if (ImGui::MenuItem("New", "Ctrl+N")) NewScene();
 
       if (ImGui::MenuItem("Open...", "Ctrl+O")) OpenScene();
@@ -214,13 +213,6 @@ void EditorLayer::OnImGuiRender() {
     ImGuizmo::SetRect(m_ViewportBounds[0].x, m_ViewportBounds[0].y,
                       m_ViewportBounds[1].x - m_ViewportBounds[0].x,
                       m_ViewportBounds[1].y - m_ViewportBounds[0].y);
-
-    // Runtime camera from entity
-    // auto cameraEntity = m_ActiveScene->GetPrimaryCameraEntity();
-    // const auto& camera = cameraEntity.GetComponent<CameraComponent>().Camera;
-    // const glm::mat4& cameraProjection = camera.GetProjection();
-    // glm::mat4 cameraView =
-    // glm::inverse(cameraEntity.GetComponent<TransformComponent>().GetTransform());
 
     // Editor camera
     const glm::mat4& cameraProjection = m_EditorCamera.GetProjection();


### PR DESCRIPTION
## Summary
- Replace NULL with nullptr in OpenGLRendererAPI
- Correct project name from Hazel to Mochii in assertions
- Modernize C++ code: constexpr, enum class, smart pointers
- Clean up commented-out code and deprecated functions
- Fix typos and first-frame timestep issue
- Use modern CMake target_compile_features for C++17

Each change committed individually following conventional commit messages.